### PR TITLE
fix(FEC-7187): do not send time reached and seek events for live

### DIFF
--- a/src/kanalytics.js
+++ b/src/kanalytics.js
@@ -6,6 +6,7 @@ import Event from './event'
 
 const pluginName = "kanalytics";
 const SEEK_OFFSET: number = 2000;
+const LIVE: number = 'Live';
 
 /**
  * @classdesc
@@ -132,12 +133,12 @@ export default class KAnalytics extends BasePlugin {
    */
   _sendSeekAnalytic(): void {
     let now = new Date().getTime();
-    if (this._lastSeekEvent === 0 || this._lastSeekEvent + SEEK_OFFSET < now) {
+    if (this._lastSeekEvent + SEEK_OFFSET < now && (this.player.config.type !== LIVE || this.player.config.dvr)) {
       // avoid sending lots of seeking while scrubbing
       this._sendAnalytics(EventTypes.SEEK);
+      this._hasSeeked = true;
     }
     this._lastSeekEvent = now;
-    this._hasSeeked = true;
   }
 
   /**
@@ -146,22 +147,24 @@ export default class KAnalytics extends BasePlugin {
    * @return {void}
    */
   _sendTimePercentAnalytic(): void {
-    let percent = this.player.currentTime / this.player.duration;
-    if (!this._timePercentEvent.PLAY_REACHED_25 && percent >= .25) {
-      this._timePercentEvent.PLAY_REACHED_25 = true;
-      this._sendAnalytics(EventTypes.PLAY_REACHED_25);
-    }
-    if (!this._timePercentEvent.PLAY_REACHED_50 && percent >= .50) {
-      this._timePercentEvent.PLAY_REACHED_50 = true;
-      this._sendAnalytics(EventTypes.PLAY_REACHED_50);
-    }
-    if (!this._timePercentEvent.PLAY_REACHED_75 && percent >= .75) {
-      this._timePercentEvent.PLAY_REACHED_75 = true;
-      this._sendAnalytics(EventTypes.PLAY_REACHED_75);
-    }
-    if (!this._timePercentEvent.PLAY_REACHED_100 && percent >= .98) {
-      this._timePercentEvent.PLAY_REACHED_100 = true;
-      this._sendAnalytics(EventTypes.PLAY_REACHED_100);
+    if (this.player.config.type !== LIVE) {
+      let percent = this.player.currentTime / this.player.duration;
+      if (!this._timePercentEvent.PLAY_REACHED_25 && percent >= .25) {
+        this._timePercentEvent.PLAY_REACHED_25 = true;
+        this._sendAnalytics(EventTypes.PLAY_REACHED_25);
+      }
+      if (!this._timePercentEvent.PLAY_REACHED_50 && percent >= .50) {
+        this._timePercentEvent.PLAY_REACHED_50 = true;
+        this._sendAnalytics(EventTypes.PLAY_REACHED_50);
+      }
+      if (!this._timePercentEvent.PLAY_REACHED_75 && percent >= .75) {
+        this._timePercentEvent.PLAY_REACHED_75 = true;
+        this._sendAnalytics(EventTypes.PLAY_REACHED_75);
+      }
+      if (!this._timePercentEvent.PLAY_REACHED_100 && percent >= .98) {
+        this._timePercentEvent.PLAY_REACHED_100 = true;
+        this._sendAnalytics(EventTypes.PLAY_REACHED_100);
+      }
     }
   }
 

--- a/src/kanalytics.js
+++ b/src/kanalytics.js
@@ -133,7 +133,7 @@ export default class KAnalytics extends BasePlugin {
    */
   _sendSeekAnalytic(): void {
     let now = new Date().getTime();
-    if (this._lastSeekEvent + SEEK_OFFSET < now && (this.player.config.type !== LIVE || this.player.config.dvr)) {
+    if ((this._lastSeekEvent + SEEK_OFFSET < now) && (this.player.config.type !== LIVE || this.player.config.dvr)) {
       // avoid sending lots of seeking while scrubbing
       this._sendAnalytics(EventTypes.SEEK);
       this._hasSeeked = true;

--- a/src/kanalytics.js
+++ b/src/kanalytics.js
@@ -6,7 +6,7 @@ import Event from './event'
 
 const pluginName = "kanalytics";
 const SEEK_OFFSET: number = 2000;
-const LIVE: number = 'Live';
+const LIVE: string = 'Live';
 
 /**
  * @classdesc

--- a/test/src/kanalytics.spec.js
+++ b/test/src/kanalytics.spec.js
@@ -243,4 +243,19 @@ describe('KAnalyticsPlugin', function () {
     });
     player.load();
   });
+
+  it('should not send 25% - 100% for live', (done) => {
+    player._config.type = 'Live';
+    let onTimeUpdate = () => {
+      player.removeEventListener(player.Event.TIME_UPDATE, onTimeUpdate);
+      let payload = sendSpy.lastCall.args[0];
+      payload.event.eventType.should.equal(2);
+      done();
+    };
+    player.addEventListener(player.Event.LOADED_DATA, () => {
+      player.addEventListener(player.Event.TIME_UPDATE, onTimeUpdate);
+      player.currentTime = 12.5;
+    });
+    player.load();
+  });
 });

--- a/test/src/kanalytics.spec.js
+++ b/test/src/kanalytics.spec.js
@@ -142,6 +142,33 @@ describe('KAnalyticsPlugin', function () {
     player.load();
   });
 
+  it('should not send seek for live', (done) => {
+    player._config.type = 'Live';
+    player.addEventListener(player.Event.FIRST_PLAY, () => {
+      player.currentTime = player.duration / 2;
+    });
+    player.addEventListener(player.Event.SEEKED, () => {
+      let payload = sendSpy.lastCall.args[0];
+      payload.event.eventType.should.not.equal(17);
+      done();
+    });
+    player.play();
+  });
+
+  it('should send seek for live + dvr', (done) => {
+    player._config.type = 'Live';
+    player._config.dvr = true;
+    player.addEventListener(player.Event.FIRST_PLAY, () => {
+      player.currentTime = player.duration / 2;
+    });
+    player.addEventListener(player.Event.SEEKED, () => {
+      let payload = sendSpy.lastCall.args[0];
+      payload.event.eventType.should.equal(17);
+      done();
+    });
+    player.play();
+  });
+
   it('should send buffer start', () => {
     player.dispatchEvent({type: player.Event.PLAYER_STATE_CHANGED, payload:{
       'newState': {


### PR DESCRIPTION
### Description of the Changes
Currently we send all stats event for both vod and live. we have not send `time reached` (25%-100%) event for live at all. and send `seek` event only for vod or live+dvr.  

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
