### PR TITLE
fix(fec-7354): widget loaded event missing kaltura params

### DIFF
--- a/src/kanalytics.js
+++ b/src/kanalytics.js
@@ -64,7 +64,6 @@ export default class KAnalytics extends BasePlugin {
   constructor(name: string, player: Player, config: Object) {
     super(name, player, config);
     this._registerListeners();
-    this._sendAnalytics(EventTypes.WIDGET_LOADED);
   }
 
   /**
@@ -109,6 +108,7 @@ export default class KAnalytics extends BasePlugin {
    */
   _onSourceSelected(): void {
     this.player.ready().then(() => {
+      this._sendAnalytics(EventTypes.WIDGET_LOADED);
       this._sendAnalytics(EventTypes.MEDIA_LOADED);
     });
   }

--- a/test/src/kanalytics.spec.js
+++ b/test/src/kanalytics.spec.js
@@ -76,11 +76,15 @@ describe('KAnalyticsPlugin', function () {
       player = loadPlayer(config);
     });
 
-    it('should send widget loaded', () => {
-      let payload = sendSpy.lastCall.args[0];
-      verifyPayloadProperties(payload.ks, payload.event);
-      payload.event.seek.should.be.false;
-      payload.event.eventType.should.equal(1);
+    it('should send widget loaded', (done) => {
+      player.ready().then(() => {
+        let payload = sendSpy.firstCall.args[0];
+        verifyPayloadProperties(payload.ks, payload.event);
+        payload.event.seek.should.be.false;
+        payload.event.eventType.should.equal(1);
+        done();
+      });
+      player.load();
     });
 
     it('should send media loaded', (done) => {
@@ -262,10 +266,10 @@ describe('KAnalyticsPlugin', function () {
     it('should send 25% - 100%', (done) => {
       let onTimeUpdate = () => {
         player.removeEventListener(player.Event.TIME_UPDATE, onTimeUpdate);
-        let payload25 = sendSpy.getCall(1).args[0];
-        let payload50 = sendSpy.getCall(2).args[0];
-        let payload75 = sendSpy.getCall(3).args[0];
-        let payload100 = sendSpy.getCall(4).args[0];
+        let payload25 = sendSpy.getCall(0).args[0];
+        let payload50 = sendSpy.getCall(1).args[0];
+        let payload75 = sendSpy.getCall(2).args[0];
+        let payload100 = sendSpy.getCall(3).args[0];
         payload25.event.eventType.should.equal(4);
         payload50.event.eventType.should.equal(5);
         payload75.event.eventType.should.equal(6);


### PR DESCRIPTION
### Description of the Changes

widget loaded event triggered on the constructor where kaltura params are unknown yet.
in this change it triggered in ready promise. right before media loaded.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
