### PR TITLE
fix(FEC-7357): send widget loaded event only once

### DIFF
--- a/src/kanalytics.js
+++ b/src/kanalytics.js
@@ -54,6 +54,11 @@ export default class KAnalytics extends BasePlugin {
    * @private
    */
   _timePercentEvent: { [event: string]: boolean } = {};
+  /**
+   * Indicate whether widget loaded event already sent
+   * @private
+   */
+  _widgetLoadedEventSent: boolean = false;
 
   /**
    * @constructor
@@ -108,7 +113,10 @@ export default class KAnalytics extends BasePlugin {
    */
   _onSourceSelected(): void {
     this.player.ready().then(() => {
-      this._sendAnalytics(EventTypes.WIDGET_LOADED);
+      if (!this._widgetLoadedEventSent) {
+        this._sendAnalytics(EventTypes.WIDGET_LOADED);
+        this._widgetLoadedEventSent = true
+      }
       this._sendAnalytics(EventTypes.MEDIA_LOADED);
     });
   }

--- a/test/src/kanalytics.spec.js
+++ b/test/src/kanalytics.spec.js
@@ -370,6 +370,22 @@ describe('KAnalyticsPlugin', function () {
       player.load();
     });
 
+    it('should not send widget loaded on change media', (done) => {
+      player.addEventListener(player.Event.CHANGE_SOURCE_STARTED, () => {
+        player.addEventListener(player.Event.SOURCE_SELECTED, () => {
+          player.ready().then(() => {
+            let payload = sendSpy.lastCall.args[0];
+            verifyPayloadProperties(payload.ks, payload.event);
+            payload.event.seek.should.be.false;
+            payload.event.eventType.should.not.equal(1);
+            done();
+          });
+          player.load();
+        });
+      });
+      player.configure(CMconfig);
+    });
+
     it('should send media loaded', (done) => {
       player.addEventListener(player.Event.CHANGE_SOURCE_STARTED, () => {
         player.addEventListener(player.Event.SOURCE_SELECTED, () => {


### PR DESCRIPTION
### Description of the Changes

widget loaded is sent on each change media, while it is required only when player setup is called first time

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
