### PR TITLE
fix(FEC-7377): referrer is missing

### DIFF
--- a/src/kanalytics.js
+++ b/src/kanalytics.js
@@ -205,7 +205,7 @@ export default class KAnalytics extends BasePlugin {
       uiConfId: this.config.uiConfId || 0,
       partnerId: this.config.partnerId,
       widgetId: this.config.partnerId ? "_" + this.config.partnerId : "",
-      referrer: document.referrer
+      referrer: document.referrer || document.URL
     };
   }
 


### PR DESCRIPTION
### Description of the Changes

sometimes the kaltura stats event is missing the document referrer, since the `document.referrer` is empty. so, takes the value from `document.URL` in this case, as we do in kaltura-player.js project: 
https://github.com/kaltura/kaltura-player-js/blob/252b7e3ead6204838234fb7f7fe2b0286fb96e50/src/utils/kaltura-params.js#L71

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
