### PR TITLE
fix(FEC-7598): widget loaded not sent when preload='none'

### DIFF
--- a/src/kanalytics.js
+++ b/src/kanalytics.js
@@ -111,11 +111,11 @@ export default class KAnalytics extends BasePlugin {
    * @return {void}
    */
   _onSourceSelected(): void {
+    if (!this._widgetLoadedEventSent) {
+      this._sendAnalytics(EventTypes.WIDGET_LOADED);
+      this._widgetLoadedEventSent = true
+    }
     this.player.ready().then(() => {
-      if (!this._widgetLoadedEventSent) {
-        this._sendAnalytics(EventTypes.WIDGET_LOADED);
-        this._widgetLoadedEventSent = true
-      }
       this._sendAnalytics(EventTypes.MEDIA_LOADED);
     });
   }

--- a/test/src/kanalytics.spec.js
+++ b/test/src/kanalytics.spec.js
@@ -73,15 +73,11 @@ describe('KAnalyticsPlugin', function () {
       player = loadPlayer(config);
     });
 
-    it('should send widget loaded', (done) => {
-      player.ready().then(() => {
-        const payload = sendSpy.firstCall.args[0];
-        verifyPayloadProperties(payload.ks, payload.event);
-        payload.event.seek.should.be.false;
-        payload.event.eventType.should.equal(1);
-        done();
-      });
-      player.load();
+    it('should send widget loaded before load', () => {
+      const payload = sendSpy.firstCall.args[0];
+      verifyPayloadProperties(payload.ks, payload.event);
+      payload.event.seek.should.be.false;
+      payload.event.eventType.should.equal(1);
     });
 
     it('should send media loaded', (done) => {

--- a/test/src/kanalytics.spec.js
+++ b/test/src/kanalytics.spec.js
@@ -262,10 +262,10 @@ describe('KAnalyticsPlugin', function () {
     it('should send 25% - 100%', (done) => {
       const onTimeUpdate = () => {
         player.removeEventListener(player.Event.TIME_UPDATE, onTimeUpdate);
-        const payload25 = sendSpy.getCall(0).args[0];
-        const payload50 = sendSpy.getCall(1).args[0];
-        const payload75 = sendSpy.getCall(2).args[0];
-        const payload100 = sendSpy.getCall(3).args[0];
+        const payload25 = sendSpy.getCall(1).args[0];
+        const payload50 = sendSpy.getCall(2).args[0];
+        const payload75 = sendSpy.getCall(3).args[0];
+        const payload100 = sendSpy.getCall(4).args[0];
         payload25.event.eventType.should.equal(4);
         payload50.event.eventType.should.equal(5);
         payload75.event.eventType.should.equal(6);


### PR DESCRIPTION
### Description of the Changes
 do not wait for `ready` for sending `WIDGET_LOADED`, wait to `sourceselected` only

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
