### PR TITLE
feat(FEC-10347): expose kaltura player as a global variable instead of UMD

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,6 @@ module.exports = {
     path: __dirname + '/dist',
     filename: '[name].js',
     library: ['playkit', 'kanalytics'],
-    libraryTarget: 'umd',
     umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './kanalytics/[resource-path]'
   },
@@ -61,17 +60,7 @@ module.exports = {
     modules: [path.resolve(__dirname, 'src'), 'node_modules']
   },
   externals: {
-    'kaltura-player-js': {
-      commonjs: 'kaltura-player-js',
-      commonjs2: 'kaltura-player-js',
-      amd: 'kaltura-player-js',
-      root: ['KalturaPlayer']
-    },
-    'playkit-js-providers': {
-      commonjs: 'playkit-js-providers',
-      commonjs2: 'playkit-js-providers',
-      amd: 'playkit-js-providers',
-      root: ['KalturaPlayer', 'providers']
-    }
+    'kaltura-player-js': ['KalturaPlayer'],
+    'playkit-js-providers': ['KalturaPlayer', 'providers']
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,6 @@ module.exports = {
     path: __dirname + '/dist',
     filename: '[name].js',
     library: ['playkit', 'kanalytics'],
-    umdNamedDefine: true,
     devtoolModuleFilenameTemplate: './kanalytics/[resource-path]'
   },
   devtool: 'source-map',


### PR DESCRIPTION
### Description of the Changes

set `libraryTarget:'var'` as default.
Change the externals to use the root only.

Solves FEC-10347

BREAKING CHANGE: kanalytics plugin is not UMD anymore 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
